### PR TITLE
poll_data_channel: implement polling instead of proxying to stream

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::string::FromUtf8Error;
 use thiserror::Error;
 
@@ -34,6 +35,20 @@ pub enum Error {
 impl From<Error> for util::Error {
     fn from(e: Error) -> Self {
         util::Error::from_std(e)
+    }
+}
+
+impl From<Error> for io::Error {
+    fn from(error: Error) -> Self {
+        match error {
+            e @ Error::Sctp(sctp::Error::ErrEof) => {
+                io::Error::new(io::ErrorKind::UnexpectedEof, e.to_string())
+            }
+            e @ Error::ErrStreamClosed => {
+                io::Error::new(io::ErrorKind::ConnectionAborted, e.to_string())
+            }
+            e => io::Error::new(io::ErrorKind::Other, e.to_string()),
+        }
     }
 }
 


### PR DESCRIPTION
Since DataChannel has its own read & write implementations (which call
Stream::read and Stream::write), we can't poll stream directly, but have
to construct futures ourselves and poll them.

Most of the code was copied from sctp::Stream.