### PR TITLE
return early if the incoming stream was reset 

### DIFF
--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -139,22 +139,28 @@ impl DataChannel {
         Ok(data_channel)
     }
 
-    /// Read reads a packet of len(p) bytes as binary data
+    /// Read reads a packet of len(p) bytes as binary data.
+    ///
+    /// See [`sctp::stream::Stream::read_sctp`].
     pub async fn read(&self, buf: &mut [u8]) -> Result<usize> {
         self.read_data_channel(buf).await.map(|(n, _)| n)
     }
 
-    /// ReadDataChannel reads a packet of len(p) bytes
+    /// ReadDataChannel reads a packet of len(p) bytes. It returns the number of bytes read and
+    /// `true` if the data read is a string.
+    ///
+    /// See [`sctp::stream::Stream::read_sctp`].
     pub async fn read_data_channel(&self, buf: &mut [u8]) -> Result<(usize, bool)> {
         loop {
             //TODO: add handling of cancel read_data_channel
             let (mut n, ppi) = match self.stream.read_sctp(buf).await {
+                Ok((0, PayloadProtocolIdentifier::Unknown)) => {
+                    // The incoming stream was reset or the reading half was shutdown
+                    return Ok((0, false))
+                }
                 Ok((n, ppi)) => (n, ppi),
                 Err(err) => {
-                    // When the peer sees that an incoming stream was
-                    // reset, it also resets its corresponding outgoing stream.
-                    self.stream.shutdown(Shutdown::Both).await?;
-
+                    self.close().await?;
                     return Err(err.into());
                 }
             };

--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -156,7 +156,7 @@ impl DataChannel {
             let (mut n, ppi) = match self.stream.read_sctp(buf).await {
                 Ok((0, PayloadProtocolIdentifier::Unknown)) => {
                     // The incoming stream was reset or the reading half was shutdown
-                    return Ok((0, false))
+                    return Ok((0, false));
                 }
                 Ok((n, ppi)) => (n, ppi),
                 Err(err) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,12 +60,3 @@ impl PartialEq<util::Error> for Error {
         false
     }
 }
-
-impl PartialEq<sctp::Error> for Error {
-    fn eq(&self, other: &sctp::Error) -> bool {
-        if let Error::Sctp(e) = self {
-            return e == other;
-        }
-        false
-    }
-}


### PR DESCRIPTION
NOTE: we don't need to shutdown the stream as it was already done by the
association minus sending the reset request, which is not needed in this
case (i.e. if we've just received one, we don't need to send one back in
response).

Refs https://github.com/webrtc-rs/sctp/pull/14